### PR TITLE
Auth event management

### DIFF
--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -660,7 +660,7 @@ describe.only('Event API', () => {
     });
   });
 
-  describe('Event API update and delete', () => {
+  describe.only('Event API update and delete', () => {
     it('should update an existing event', async () => {
       const newEvent = {
         title: 'Update Me',
@@ -671,8 +671,20 @@ describe.only('Event API', () => {
         end_time: '2025-08-01T12:00:00.000Z',
       };
 
+      const loginRes = await request(app)
+        .post('/api/login')
+        .send({
+          email: 'mensah@preservationaux.com',
+          password: 'preservationalliance',
+        })
+        .expect(200);
+
+      const token = loginRes.body.token;
+      if (!token) throw new Error('No token returned from login');
+
       const createRes = await request(app)
         .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
         .send(newEvent)
         .expect(201);
 
@@ -689,6 +701,7 @@ describe.only('Event API', () => {
 
       const updateRes = await request(app)
         .patch(`/api/events/${eventId}`)
+        .set('Authorization', `Bearer ${token}`)
         .send(updatedFields)
         .expect(200);
 

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -660,7 +660,7 @@ describe.only('Event API', () => {
     });
   });
 
-  describe.only('Event API update and delete', () => {
+  describe('Event API update and delete', () => {
     it('should update an existing event', async () => {
       const newEvent = {
         title: 'Update Me',
@@ -730,14 +730,29 @@ describe.only('Event API', () => {
         end_time: '2025-08-01T12:00:00.000Z',
       };
 
+      const loginRes = await request(app)
+        .post('/api/login')
+        .send({
+          email: 'mensah@preservationaux.com',
+          password: 'preservationalliance',
+        })
+        .expect(200);
+
+      const token = loginRes.body.token;
+      if (!token) throw new Error('No token returned from login');
+
       const createRes = await request(app)
         .post('/api/events')
+        .set('Authorization', `Bearer ${token}`)
         .send(newEvent)
         .expect(201);
 
       const eventId = createRes.body.id;
 
-      await request(app).delete(`/api/events/${eventId}`).expect(204);
+      await request(app)
+        .delete(`/api/events/${eventId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
 
       await request(app).get(`/api/events/${eventId}`).expect(404);
     });

--- a/src/controllers/appController.ts
+++ b/src/controllers/appController.ts
@@ -55,7 +55,6 @@ export const loginUser =
       if (error.status === 401) {
         return res.status(401).json({ message: 'Incorrect email or password' });
       }
-      console.log('Error logging in user:', error);
       next(error);
     }
   };

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -36,6 +36,14 @@ export const createEvent =
     res: Response,
     next: NextFunction
   ) => {
+    const user = (req as any).user;
+
+    if (!user || !user.userId) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    const created_by = user?.userId;
+
     const {
       title,
       description,
@@ -46,9 +54,6 @@ export const createEvent =
       image_url,
       image_alt_text,
     } = req.body;
-
-    const user = (req as any).user;
-    const created_by = user?.id;
 
     if (
       !title ||

--- a/src/db/testData/attendeeTestData.ts
+++ b/src/db/testData/attendeeTestData.ts
@@ -4,6 +4,6 @@ export const attendeeTestData: EventAttendee[] = [
   { user_id: '1', event_id: '1', status: 'attending' },
   { user_id: '1', event_id: '2', status: 'attending' },
 
-  { user_id: '2', event_id: '2', status: 'cancelled' },
+  { user_id: '2', event_id: '2', status: 'attending' },
   { user_id: '2', event_id: '1', status: 'attending' },
 ];

--- a/src/middleware/authenticateJWT.ts
+++ b/src/middleware/authenticateJWT.ts
@@ -14,9 +14,7 @@ export function authenticateJWT(
 
     jwt.verify(token, process.env.JWT_SECRET as string, (err, decoded) => {
       if (err) return res.status(403).json({ message: 'Invalid token' });
-
       req.user = decoded as JwtPayload;
-
       next();
     });
   } else {

--- a/src/models/eventModel.ts
+++ b/src/models/eventModel.ts
@@ -51,14 +51,15 @@ export const eventModel = {
       !location ||
       price === undefined ||
       !start_time ||
-      !end_time
+      !end_time ||
+      !created_by
     ) {
       throw makeError('Missing required fields', 400);
     }
     const result = await db.query(
-      `INSERT INTO events (title, description, location, price, start_time, end_time, image_url, image_alt_text, created_by,)
+      `INSERT INTO events (title, description, location, price, start_time, end_time, image_url, image_alt_text, created_by)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-      RETURNING id, title, description, location, price, start_time, end_time,  image_url, image_alt_text, created_by,`,
+      RETURNING id, title, description, location, price, start_time, end_time,  image_url, image_alt_text, created_by`,
       [
         title,
         description,

--- a/src/routes/appRoutes.ts
+++ b/src/routes/appRoutes.ts
@@ -16,9 +16,7 @@ router.post('/register', createUser(userModel));
 router.post('/login', loginUser(userModel));
 
 router.get('/protected', authenticateJWT, (req, res) => {
-  res
-    .status(200)
-    .json({ message: 'You have access!', user: (req as any).user });
+  res.status(200).json({ message: 'You have access!', user: req.user });
 });
 
 export default router;

--- a/src/routes/eventRoutes.ts
+++ b/src/routes/eventRoutes.ts
@@ -10,15 +10,16 @@ import {
   updateAttendeeStatus,
 } from '../controllers/eventController';
 import { eventModel } from '../models/eventModel';
+import { authenticateJWT } from '../middleware/authenticateJWT';
 
 const router = Router();
 
 router.get('/', getEvents(eventModel));
-router.post('/', createEvent(eventModel));
+router.post('/', authenticateJWT, createEvent(eventModel));
 
 router.get('/:event_id', getEventDetails(eventModel));
-router.patch('/:event_id', updateEvent(eventModel));
-router.delete('/:event_id', deleteEvent(eventModel));
+router.patch('/:event_id', authenticateJWT, updateEvent(eventModel));
+router.delete('/:event_id', authenticateJWT, deleteEvent(eventModel));
 
 router.post('/:event_id/attendees', addAttendee(eventModel));
 router.get('/:event_id/attendees', getAttendeesForEvent(eventModel));

--- a/src/routes/eventRoutes.ts
+++ b/src/routes/eventRoutes.ts
@@ -21,8 +21,12 @@ router.get('/:event_id', getEventDetails(eventModel));
 router.patch('/:event_id', authenticateJWT, updateEvent(eventModel));
 router.delete('/:event_id', authenticateJWT, deleteEvent(eventModel));
 
-router.post('/:event_id/attendees', addAttendee(eventModel));
+router.post('/:event_id/attendees', authenticateJWT, addAttendee(eventModel));
 router.get('/:event_id/attendees', getAttendeesForEvent(eventModel));
-router.patch('/:event_id/attendees/:user_id', updateAttendeeStatus(eventModel));
+router.patch(
+  '/:event_id/attendees/:user_id',
+  authenticateJWT,
+  updateAttendeeStatus(eventModel)
+);
 
 export default router;


### PR DESCRIPTION
This PR adds authentication to multiple routes, including:

- POST, PATCH and DELETE events, ensuring only logged-in users can create and edit their own events
- POST and PATCH attendee status, ensuring only logged-in users can create and edit their own event RSVPs

Models, controllers and routes have been updated to reflect the use of JWT authentication.

The test suite has been updated to reflect changes to request handling.